### PR TITLE
Fix thermos compat with ThaumicBases

### DIFF
--- a/src/main/java/com/kuba6000/mobsinfo/loader/MobRecipeLoader.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/MobRecipeLoader.java
@@ -481,7 +481,7 @@ public class MobRecipeLoader {
 
             @SuppressWarnings("unused") // for thermos compat
             public UUID getUUID() {
-                return UUID.randomUUID();
+                return UUID.nameUUIDFromBytes("MobsInfoDummyWorld".getBytes(StandardCharsets.UTF_8));
             }
         }, "DUMMY_DIMENSION", new WorldSettings(new WorldInfo(new NBTTagCompound())), null, new Profiler()) {
 

--- a/src/main/java/com/kuba6000/mobsinfo/loader/MobRecipeLoader.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/MobRecipeLoader.java
@@ -478,6 +478,11 @@ public class MobRecipeLoader {
             public File getWorldDirectory() {
                 return null;
             }
+
+            @SuppressWarnings("unused") // for thermos compat
+            public UUID getUUID() {
+                return UUID.randomUUID();
+            }
         }, "DUMMY_DIMENSION", new WorldSettings(new WorldInfo(new NBTTagCompound())), null, new Profiler()) {
 
             @Override


### PR DESCRIPTION
thermos [add an abstract method to ISaveHandler interface](https://github.com/GTNewHorizons/Thermos/blob/1.7.10/patches/net/minecraft/world/storage/ISaveHandler.java.patch) that will be called by thermos modified Entity.writeToNBT(), which will be called by ThaumicBases as part of its call to `ScanManager.generateEntityAspects()`