### PR TITLE
Fix bug where language strings did not change when the client changed its language.

### DIFF
--- a/src/main/java/com/kuba6000/mobsinfo/ClientProxy.java
+++ b/src/main/java/com/kuba6000/mobsinfo/ClientProxy.java
@@ -20,6 +20,14 @@
 
 package com.kuba6000.mobsinfo;
 
+import java.util.HashMap;
+import java.util.HashSet;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+
+import com.kuba6000.mobsinfo.api.MobOverride;
 import com.kuba6000.mobsinfo.api.utils.ModUtils;
 import com.kuba6000.mobsinfo.loader.MobRecipeLoader;
 import com.kuba6000.mobsinfo.loader.VillagerTradesLoader;
@@ -38,6 +46,9 @@ import cpw.mods.fml.common.event.FMLServerStoppingEvent;
 @SuppressWarnings("unused")
 public class ClientProxy extends CommonProxy {
 
+    public static HashSet<String> mobsToLoad = new HashSet<>();
+    public static HashMap<String, MobOverride> mobsOverrides = new HashMap<>();
+
     @Override
     public void preInit(FMLPreInitializationEvent event) {
         ModUtils.isClientSided = true;
@@ -53,6 +64,7 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void postInit(FMLPostInitializationEvent event) {
         super.postInit(event);
+        registerLanguageReload();
     }
 
     @Override
@@ -85,5 +97,14 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void serverStopped(FMLServerStoppedEvent event) {
         super.serverStopped(event);
+    }
+
+    @Override
+    public void registerLanguageReload() {
+        if (Minecraft.getMinecraft()
+            .getResourceManager() instanceof IReloadableResourceManager manager) {
+            manager.registerReloadListener(
+                (IResourceManager manager2) -> { MobRecipeLoader.processMobRecipeMap(mobsToLoad, mobsOverrides); });
+        }
     }
 }

--- a/src/main/java/com/kuba6000/mobsinfo/CommonProxy.java
+++ b/src/main/java/com/kuba6000/mobsinfo/CommonProxy.java
@@ -77,4 +77,6 @@ public class CommonProxy {
     public void serverStopping(FMLServerStoppingEvent event) {}
 
     public void serverStopped(FMLServerStoppedEvent event) {}
+
+    public void registerLanguageReload() {}
 }

--- a/src/main/java/com/kuba6000/mobsinfo/network/LoadConfigPacket.java
+++ b/src/main/java/com/kuba6000/mobsinfo/network/LoadConfigPacket.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import com.kuba6000.mobsinfo.ClientProxy;
 import com.kuba6000.mobsinfo.MobsInfo;
 import com.kuba6000.mobsinfo.api.MobOverride;
 import com.kuba6000.mobsinfo.config.Config;
@@ -107,6 +108,8 @@ public class LoadConfigPacket implements IMessage {
 
         @Override
         public IMessage onMessage(LoadConfigPacket message, MessageContext ctx) {
+            ClientProxy.mobsToLoad = message.mobsToLoad;
+            ClientProxy.mobsOverrides = message.mobsOverrides;
             MobsInfo.info("Received Mobs-Info config, parsing");
             MobRecipeLoader.processMobRecipeMap(message.mobsToLoad, message.mobsOverrides);
             VillagerTradesLoader.processVillagerTrades(message.villagersToLoad);


### PR DESCRIPTION
Example of the bug when switching from Russian to English:
![image](https://github.com/user-attachments/assets/42a36624-f61e-4695-a9d3-df4216394586)

This was fixed by caching the mobs to load and overrides on the client to let it rebuild the mob recipe map on language change.
Tested and this fixes the bug on SP worlds and a local server in the dev environment.

Example of switching from English to Russian and then back to English with this fix (expected behavior):
![image](https://github.com/user-attachments/assets/e7e2af74-0b3f-494b-9cf6-306bfd849a25)
![image](https://github.com/user-attachments/assets/9dc91750-d503-43ed-9f91-bc16e0c25131)
