### PR TITLE
Check TC Aspects NBT

### DIFF
--- a/src/main/java/com/kuba6000/mobsinfo/nei/MobHandler.java
+++ b/src/main/java/com/kuba6000/mobsinfo/nei/MobHandler.java
@@ -584,7 +584,12 @@ public class MobHandler extends TemplateRecipeHandler implements IScrollableGUI 
 
     @Override
     public void loadCraftingRecipes(ItemStack result) {
-        if (LoaderReference.Gregtech5.isLoaded) {
+        if (LoaderReference.Thaumcraft.isLoaded && result.hasTagCompound()
+            && result.getTagCompound()
+                .hasKey("Aspects", 9)) {
+            for (MobCachedRecipe r : cachedRecipes)
+                if (r.containsWithNBT(r.mOutputs, result) && r.isUnlocked()) arecipes.add(r);
+        } else if (LoaderReference.Gregtech5.isLoaded) {
             List<ItemStack> results = GT5Helper.getAssociated(result);
             for (MobCachedRecipe r : cachedRecipes) if (results.stream()
                 .anyMatch(i -> r.contains(r.mOutputs, i)) && r.isUnlocked()) arecipes.add(r);


### PR DESCRIPTION
Thaumcraft and some addons have items that use the NBT compound tag "Aspects" to distinguish items with different aspects and amounts on them. This includes Crystallized Essence, Ethereal Essence, Phial of Essentia, Node in a Jar, Attuned Node Matrix (ThaumicMechanics), and Aspect: [insert here] (Thaumcraft NEI Plugin). The ones that matter for mob drops, in GT:NH at least, are the itemized essences.

Currently, when a player tries to check the recipe for one of these items with a specific aspect, the mod does not check the Aspects tag and returns all mobs that drop the item type. Looking for Crystallized Lux in GT:NH shows 282 mobs that drop any kind of Crystallized Essence. This PR makes it show only the 1 mob that actually drops it by having any item with the Aspects compound tag match with NBT.

Trying to find Crystallized Lux before PR:
<img width="690" height="957" alt="image" src="https://github.com/user-attachments/assets/8a2c65d7-b945-4949-828a-913e75de979c" />

Easily finding Crystallized Lux after PR:
<img width="691" height="957" alt="image" src="https://github.com/user-attachments/assets/9ee588b3-c67a-41c8-92a2-68b29075fb18" />
