### PR TITLE
Add default constructor to LycanitesMobsOrOnYuletideDay

### DIFF
--- a/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
@@ -182,6 +182,8 @@ public class LycanitesMobs implements IExtraLoader {
 
         double chance;
 
+        public LycanitesMobsOrOnYuletideDay() {}
+        
         public LycanitesMobsOrOnYuletideDay(double chance) {
             this.chance = chance;
         }

--- a/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
@@ -183,7 +183,7 @@ public class LycanitesMobs implements IExtraLoader {
         double chance;
 
         public LycanitesMobsOrOnYuletideDay() {}
-        
+
         public LycanitesMobsOrOnYuletideDay(double chance) {
             this.chance = chance;
         }

--- a/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
+++ b/src/main/java/com/kuba6000/mobsinfo/loader/extras/LycanitesMobs.java
@@ -182,7 +182,7 @@ public class LycanitesMobs implements IExtraLoader {
 
         double chance;
 
-        public LycanitesMobsOrOnYuletideDay() {}
+        protected LycanitesMobsOrOnYuletideDay() {}
 
         public LycanitesMobsOrOnYuletideDay(double chance) {
             this.chance = chance;


### PR DESCRIPTION
Fix

```
Caught exception from mobsinfo
java.lang.RuntimeException: java.lang.NoSuchMethodException:
  com.kuba6000.mobsinfo.loader.extras.LycanitesMobs$LycanitesMobsOrOnYuletideDay.<init>()
    at com.kuba6000.mobsinfo.loader.extras.ExtraLoader.process(ExtraLoader.java:172)
    at com.kuba6000.mobsinfo.loader.MobRecipeLoader.processMobRecipeMap(...)
    at com.kuba6000.mobsinfo.CommonProxy.serverStarting(CommonProxy.java:66)
```